### PR TITLE
Update requirements.txt with missing package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 akshare
 tushare
 finnhub-python
-
+parsel
 requests
 pandas
 tqdm


### PR DESCRIPTION
While trying to import the CNBC_Streaming getting an error

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'parsel' is not defined
so adding the missing package